### PR TITLE
Use OSs supported by Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
   - '0.12'
 os:
   - linux
-  - windows
+  - osx
 before_script:
   - npm install -g istanbul
   - npm install -g mocha


### PR DESCRIPTION
Travis CI does not do windows.  It does linux + osx.  See https://docs.travis-ci.com/user/multi-os/